### PR TITLE
Edit CSS for feature overview SVGs

### DIFF
--- a/addon/tailwind/components/bourbon-feature-overview.css
+++ b/addon/tailwind/components/bourbon-feature-overview.css
@@ -7,13 +7,8 @@
   margin: 60px auto;
 }
 
-.bourbon-feature-overview__img-container {
-  height: 242px;
-  margin-bottom: 35px;
-}
-
 .bourbon-feature-overview__svg-container {
-  height: 258px;
+  margin-bottom: 25px;
 }
 
 .bourbon-feature-overview__text-container {

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1332,9 +1332,8 @@ body {
   margin: 60px auto;
 }
 
-.bourbon-feature-overview__img-container {
-  height: 242px;
-  margin-bottom: 35px;
+.bourbon-feature-overview__svg-container {
+  margin-bottom: 25px;
 }
 
 .bourbon-feature-overview__text-container {


### PR DESCRIPTION
Edit CSS for feature overview SVGs (give margin bottom) 

`bourbon-feature-overview__img-container` wasn't used anywhere in bourbon or flabongo code base