### PR TITLE
fixing width for alert badge on ff

### DIFF
--- a/addon/tailwind/components/bourbon-alert-badge.css
+++ b/addon/tailwind/components/bourbon-alert-badge.css
@@ -1,6 +1,7 @@
 
 .bourbon-alert-badge__container {
   width: 55%;  /* this is fallback for IE which doesn't support fit-content */
+  width: -moz-fit-content;
   width: fit-content;
   border: 1px solid;
   @apply .bourbon-border-fern;

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1141,6 +1141,7 @@ body {
 
 .bourbon-alert-badge__container {
   width: 55%; /* this is fallback for IE which doesn't support fit-content */
+  width: -moz-fit-content;
   width: fit-content;
   border: 1px solid;
   border-color: #48ba70;


### PR DESCRIPTION
BEFORE
<img width="827" alt="screen shot 2018-11-30 at 3 46 14 pm" src="https://user-images.githubusercontent.com/1967604/49320558-20b93000-f4b7-11e8-8fe8-39c210495eba.png">

AFTER
<img width="726" alt="screen shot 2018-11-30 at 3 45 56 pm" src="https://user-images.githubusercontent.com/1967604/49320559-20b93000-f4b7-11e8-988f-9a9f48fd248a.png">
