### PR TITLE
5561: styling update to bourbon modal

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "shinnn.stylelint",
-    "zignd.html-css-class-completion"
-  ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "css.validate": false, // Disable css built-in lint
-	"stylelint.enable": true, // Enable sytlelint
-}

--- a/addon/services/modal.js
+++ b/addon/services/modal.js
@@ -10,7 +10,6 @@ export default Service.extend({
       buttonOneDontClose: false,
       buttonTwoDontClose: false,
       wideModal: false,
-      confirmationModal: false,
       noPaddingModal: false,
       closeAction: null,
       title: null,

--- a/addon/tailwind/components/bourbon-modal.css
+++ b/addon/tailwind/components/bourbon-modal.css
@@ -21,11 +21,12 @@
   width: 550px;
   padding: 35px;
   z-index: 7;
+  text-align: left;
 
+  @apply .btw-text-light-tuna;
   @apply .btw-border-grey-light;
   @apply .btw-bg-white;
   @apply .btw-rounded;
-
   @apply .btw-border;
   @apply .btw-border-solid;
   @apply .btw-border-mercury;
@@ -44,30 +45,24 @@
 }
 
 .BourbonModal-title {
-  text-align: center;
-  @apply .btw-text-xl;
-  @apply .btw-font-semibold;
+  font-size: 28px;
+  line-height: 39px;
+  @apply .btw-text-3xl;
   @apply .btw-antialiased;
 
   @apply .btw-mt-2;
   @apply .btw-mb-8;
 }
 
-.BourbonModal--confirmation .BourbonModal-title {
-  text-align: left;
-  @apply .btw-text-lg;
-  @apply .btw-mb-4;
-}
-
+.BourbonModal--subheader,
 .BourbonModal-dialog {
-  text-align: left;
-  @apply .btw-text-base;
+  @apply .btw-text-md;
   @apply .btw-mb-9;
+
+  line-height: 22px;
 }
 
 .BourbonModal-content {
-  text-align: center;
-
   @apply .btw-leading-normal;
   @apply .btw-mb-6;
 }
@@ -83,8 +78,8 @@
 
 .BourbonModal-closeButton {
   position: absolute;
-  right: -26px;
-  top: -31px;
+  right: -11px;
+  top: -22px;
   height: auto;
   min-width: 0;
   padding: 0;
@@ -130,19 +125,13 @@
 
 /* scrollable modal styles */
 .BourbonModal--scrollable {
-  padding: 35px 0;
   display: grid;
   grid-template-rows: 60px auto 60px;
   height: 600px;
 }
 
-.BourbonModal--scrollable .BourbonModal-closeButton {
-  right: 8px;
-}
-
 .BourbonModal--scrollable .BourbonModal-content {
   overflow-y: auto;
-  padding: 0 35px;
   margin-bottom: 0;
 }
 
@@ -166,7 +155,6 @@
   @apply .btw-p-0;
   @apply .btw-m-0;
   border: none;
-  width: auto;
 }
 
 .BourbonModal--noPadding .BourbonModal-closeButton {

--- a/addon/tailwind/config/colors.js
+++ b/addon/tailwind/config/colors.js
@@ -26,6 +26,7 @@ export default {
   'black': '#000',
   'white': '#FFF',
   'slate': '#474C4F',
+  'light-tuna': '#3E3F42',
   'tuna': 'rgba(60,64,67,0.90)',
   'alto': '#DCDCDC',
   'alabaster': '#FAFAFA',

--- a/addon/tailwind/config/text-sizes.js
+++ b/addon/tailwind/config/text-sizes.js
@@ -25,7 +25,7 @@ export default {
   lg: '1.125rem', // 18px
   xl: '1.25rem', // 20px
   '2xl': '1.5rem', // 24px
-  '3xl': '1.875rem', // 30px
+  '3xl': '1.75rem', // 28px
   '4xl': '2.25rem', // 36px
   '5xl': '3rem' // 48px
 };

--- a/addon/templates/components/bourbon-modal.hbs
+++ b/addon/templates/components/bourbon-modal.hbs
@@ -1,6 +1,6 @@
 {{#if modalService.showModalState}}
   {{bourbon-modal-overlay closeModal=(action 'closeBourbonModal')}}
-  <aside class="BourbonModal {{if modalService.scrollable 'BourbonModal--scrollable'}} {{if modalService.wideModal 'BourbonModal--large'}} {{if modalService.confirmationModal 'BourbonModal--confirmation'}} {{if modalService.noPaddingModal 'BourbonModal--noPadding'}} {{if modalService.hideFooter 'BourbonModal--hideFooter'}}">
+  <aside class="BourbonModal {{if modalService.scrollable 'BourbonModal--scrollable'}} {{if modalService.wideModal 'BourbonModal--large'}} {{if modalService.noPaddingModal 'BourbonModal--noPadding'}} {{if modalService.hideFooter 'BourbonModal--hideFooter'}}">
     <div class="BourbonModal-header">
       {{#if modalService.title}}
         <header class="BourbonModal-title">{{modalService.title}}</header>

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1457,6 +1457,8 @@ body {
   width: 550px;
   padding: 35px;
   z-index: 7;
+  text-align: left;
+  color: #3e3f42;
   border-color: #d3d3d3;
   background-color: #fff;
   border-radius: .25rem;
@@ -1478,29 +1480,23 @@ body {
 }
 
 .BourbonModal-title {
-  text-align: center;
-  font-size: 1.25rem;
-  font-weight: 600;
+  font-size: 28px;
+  line-height: 39px;
+  font-size: 1.75rem;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin-top: .5rem;
   margin-bottom: 2rem;
 }
 
-.BourbonModal--confirmation .BourbonModal-title {
-  text-align: left;
-  font-size: 1.125rem;
-  margin-bottom: 1rem;
-}
-
+.BourbonModal--subheader,
 .BourbonModal-dialog {
-  text-align: left;
-  font-size: 1rem;
+  font-size: .875rem;
   margin-bottom: 3rem;
+  line-height: 22px;
 }
 
 .BourbonModal-content {
-  text-align: center;
   line-height: 1.5;
   margin-bottom: 1.5rem;
 }
@@ -1516,8 +1512,8 @@ body {
 
 .BourbonModal-closeButton {
   position: absolute;
-  right: -26px;
-  top: -31px;
+  right: -11px;
+  top: -22px;
   height: auto;
   min-width: 0;
   padding: 0;
@@ -1563,19 +1559,13 @@ body {
 /* scrollable modal styles */
 
 .BourbonModal--scrollable {
-  padding: 35px 0;
   display: grid;
   grid-template-rows: 60px auto 60px;
   height: 600px;
 }
 
-.BourbonModal--scrollable .BourbonModal-closeButton {
-  right: 8px;
-}
-
 .BourbonModal--scrollable .BourbonModal-content {
   overflow-y: auto;
-  padding: 0 35px;
   margin-bottom: 0;
 }
 
@@ -1599,7 +1589,6 @@ body {
   padding: 0;
   margin: 0;
   border: none;
-  width: auto;
 }
 
 .BourbonModal--noPadding .BourbonModal-closeButton {
@@ -1966,6 +1955,10 @@ body {
   background-color: #474c4f;
 }
 
+.btw-bg-light-tuna {
+  background-color: #3e3f42;
+}
+
 .btw-bg-tuna {
   background-color: rgba(60, 64, 67, .9);
 }
@@ -2032,6 +2025,10 @@ body {
 
 .hover\:btw-bg-slate:hover {
   background-color: #474c4f;
+}
+
+.hover\:btw-bg-light-tuna:hover {
+  background-color: #3e3f42;
 }
 
 .hover\:btw-bg-tuna:hover {
@@ -2166,6 +2163,10 @@ body {
   border-color: #474c4f;
 }
 
+.btw-border-light-tuna {
+  border-color: #3e3f42;
+}
+
 .btw-border-tuna {
   border-color: rgba(60, 64, 67, .9);
 }
@@ -2232,6 +2233,10 @@ body {
 
 .hover\:btw-border-slate:hover {
   border-color: #474c4f;
+}
+
+.hover\:btw-border-light-tuna:hover {
+  border-color: #3e3f42;
 }
 
 .hover\:btw-border-tuna:hover {
@@ -4176,6 +4181,10 @@ body {
   color: #474c4f;
 }
 
+.btw-text-light-tuna {
+  color: #3e3f42;
+}
+
 .btw-text-tuna {
   color: rgba(60, 64, 67, .9);
 }
@@ -4244,6 +4253,10 @@ body {
   color: #474c4f;
 }
 
+.hover\:btw-text-light-tuna:hover {
+  color: #3e3f42;
+}
+
 .hover\:btw-text-tuna:hover {
   color: rgba(60, 64, 67, .9);
 }
@@ -4309,7 +4322,7 @@ body {
 }
 
 .btw-text-3xl {
-  font-size: 1.875rem;
+  font-size: 1.75rem;
 }
 
 .btw-text-4xl {
@@ -4801,6 +4814,10 @@ button:focus {
     background-color: #474c4f;
   }
 
+  .sm\:btw-bg-light-tuna {
+    background-color: #3e3f42;
+  }
+
   .sm\:btw-bg-tuna {
     background-color: rgba(60, 64, 67, .9);
   }
@@ -4867,6 +4884,10 @@ button:focus {
 
   .sm\:hover\:btw-bg-slate:hover {
     background-color: #474c4f;
+  }
+
+  .sm\:hover\:btw-bg-light-tuna:hover {
+    background-color: #3e3f42;
   }
 
   .sm\:hover\:btw-bg-tuna:hover {
@@ -5001,6 +5022,10 @@ button:focus {
     border-color: #474c4f;
   }
 
+  .sm\:btw-border-light-tuna {
+    border-color: #3e3f42;
+  }
+
   .sm\:btw-border-tuna {
     border-color: rgba(60, 64, 67, .9);
   }
@@ -5067,6 +5092,10 @@ button:focus {
 
   .sm\:hover\:btw-border-slate:hover {
     border-color: #474c4f;
+  }
+
+  .sm\:hover\:btw-border-light-tuna:hover {
+    border-color: #3e3f42;
   }
 
   .sm\:hover\:btw-border-tuna:hover {
@@ -7003,6 +7032,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .sm\:btw-text-light-tuna {
+    color: #3e3f42;
+  }
+
   .sm\:btw-text-tuna {
     color: rgba(60, 64, 67, .9);
   }
@@ -7071,6 +7104,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .sm\:hover\:btw-text-light-tuna:hover {
+    color: #3e3f42;
+  }
+
   .sm\:hover\:btw-text-tuna:hover {
     color: rgba(60, 64, 67, .9);
   }
@@ -7136,7 +7173,7 @@ button:focus {
   }
 
   .sm\:btw-text-3xl {
-    font-size: 1.875rem;
+    font-size: 1.75rem;
   }
 
   .sm\:btw-text-4xl {
@@ -7520,6 +7557,10 @@ button:focus {
     background-color: #474c4f;
   }
 
+  .md\:btw-bg-light-tuna {
+    background-color: #3e3f42;
+  }
+
   .md\:btw-bg-tuna {
     background-color: rgba(60, 64, 67, .9);
   }
@@ -7586,6 +7627,10 @@ button:focus {
 
   .md\:hover\:btw-bg-slate:hover {
     background-color: #474c4f;
+  }
+
+  .md\:hover\:btw-bg-light-tuna:hover {
+    background-color: #3e3f42;
   }
 
   .md\:hover\:btw-bg-tuna:hover {
@@ -7720,6 +7765,10 @@ button:focus {
     border-color: #474c4f;
   }
 
+  .md\:btw-border-light-tuna {
+    border-color: #3e3f42;
+  }
+
   .md\:btw-border-tuna {
     border-color: rgba(60, 64, 67, .9);
   }
@@ -7786,6 +7835,10 @@ button:focus {
 
   .md\:hover\:btw-border-slate:hover {
     border-color: #474c4f;
+  }
+
+  .md\:hover\:btw-border-light-tuna:hover {
+    border-color: #3e3f42;
   }
 
   .md\:hover\:btw-border-tuna:hover {
@@ -9722,6 +9775,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .md\:btw-text-light-tuna {
+    color: #3e3f42;
+  }
+
   .md\:btw-text-tuna {
     color: rgba(60, 64, 67, .9);
   }
@@ -9790,6 +9847,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .md\:hover\:btw-text-light-tuna:hover {
+    color: #3e3f42;
+  }
+
   .md\:hover\:btw-text-tuna:hover {
     color: rgba(60, 64, 67, .9);
   }
@@ -9855,7 +9916,7 @@ button:focus {
   }
 
   .md\:btw-text-3xl {
-    font-size: 1.875rem;
+    font-size: 1.75rem;
   }
 
   .md\:btw-text-4xl {
@@ -10239,6 +10300,10 @@ button:focus {
     background-color: #474c4f;
   }
 
+  .lg\:btw-bg-light-tuna {
+    background-color: #3e3f42;
+  }
+
   .lg\:btw-bg-tuna {
     background-color: rgba(60, 64, 67, .9);
   }
@@ -10305,6 +10370,10 @@ button:focus {
 
   .lg\:hover\:btw-bg-slate:hover {
     background-color: #474c4f;
+  }
+
+  .lg\:hover\:btw-bg-light-tuna:hover {
+    background-color: #3e3f42;
   }
 
   .lg\:hover\:btw-bg-tuna:hover {
@@ -10439,6 +10508,10 @@ button:focus {
     border-color: #474c4f;
   }
 
+  .lg\:btw-border-light-tuna {
+    border-color: #3e3f42;
+  }
+
   .lg\:btw-border-tuna {
     border-color: rgba(60, 64, 67, .9);
   }
@@ -10505,6 +10578,10 @@ button:focus {
 
   .lg\:hover\:btw-border-slate:hover {
     border-color: #474c4f;
+  }
+
+  .lg\:hover\:btw-border-light-tuna:hover {
+    border-color: #3e3f42;
   }
 
   .lg\:hover\:btw-border-tuna:hover {
@@ -12441,6 +12518,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .lg\:btw-text-light-tuna {
+    color: #3e3f42;
+  }
+
   .lg\:btw-text-tuna {
     color: rgba(60, 64, 67, .9);
   }
@@ -12509,6 +12590,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .lg\:hover\:btw-text-light-tuna:hover {
+    color: #3e3f42;
+  }
+
   .lg\:hover\:btw-text-tuna:hover {
     color: rgba(60, 64, 67, .9);
   }
@@ -12574,7 +12659,7 @@ button:focus {
   }
 
   .lg\:btw-text-3xl {
-    font-size: 1.875rem;
+    font-size: 1.75rem;
   }
 
   .lg\:btw-text-4xl {
@@ -12958,6 +13043,10 @@ button:focus {
     background-color: #474c4f;
   }
 
+  .xl\:btw-bg-light-tuna {
+    background-color: #3e3f42;
+  }
+
   .xl\:btw-bg-tuna {
     background-color: rgba(60, 64, 67, .9);
   }
@@ -13024,6 +13113,10 @@ button:focus {
 
   .xl\:hover\:btw-bg-slate:hover {
     background-color: #474c4f;
+  }
+
+  .xl\:hover\:btw-bg-light-tuna:hover {
+    background-color: #3e3f42;
   }
 
   .xl\:hover\:btw-bg-tuna:hover {
@@ -13158,6 +13251,10 @@ button:focus {
     border-color: #474c4f;
   }
 
+  .xl\:btw-border-light-tuna {
+    border-color: #3e3f42;
+  }
+
   .xl\:btw-border-tuna {
     border-color: rgba(60, 64, 67, .9);
   }
@@ -13224,6 +13321,10 @@ button:focus {
 
   .xl\:hover\:btw-border-slate:hover {
     border-color: #474c4f;
+  }
+
+  .xl\:hover\:btw-border-light-tuna:hover {
+    border-color: #3e3f42;
   }
 
   .xl\:hover\:btw-border-tuna:hover {
@@ -15160,6 +15261,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .xl\:btw-text-light-tuna {
+    color: #3e3f42;
+  }
+
   .xl\:btw-text-tuna {
     color: rgba(60, 64, 67, .9);
   }
@@ -15228,6 +15333,10 @@ button:focus {
     color: #474c4f;
   }
 
+  .xl\:hover\:btw-text-light-tuna:hover {
+    color: #3e3f42;
+  }
+
   .xl\:hover\:btw-text-tuna:hover {
     color: rgba(60, 64, 67, .9);
   }
@@ -15293,7 +15402,7 @@ button:focus {
   }
 
   .xl\:btw-text-3xl {
-    font-size: 1.875rem;
+    font-size: 1.75rem;
   }
 
   .xl\:btw-text-4xl {

--- a/tests/dummy/app/templates/components/modals.hbs
+++ b/tests/dummy/app/templates/components/modals.hbs
@@ -111,30 +111,6 @@
   ```
 {{/freestyle-note}}
 
-
-{{#freestyle-usage 'bourbon-confirmation-modal' title='confirmation modal' usageTitle='Usage'}}
-    {{bourbon-button title='Show confirmation modal' class='BourbonButton--primary' action=(action 'showBourbonModal'
-    confirmationModalParams)}}
-{{/freestyle-usage}}
-
-{{#freestyle-note 'bourbon-confirmation-modal--notes'}}
-  <div class="FreestyleUsage-rendered">Params being passed into the example</div>
-  ```
-    this.set('confirmationModalParams', {
-      confirmationModal: true,
-      closeAction: this.controllerCloseAction,
-      title: 'Are you sure?',
-      textContent: 'Would you like to delete your connection?',
-      buttonOneTitle: 'Delete',
-      buttonOneAction: this.primaryClick,
-      buttonOneType: 'delete',
-      buttonTwoTitle: 'Cancel',
-      buttonTwoAction: () => this.secondaryClick('anonymous'),
-    })
-  ```
-{{/freestyle-note}}
-
-
 {{#freestyle-usage 'bourbon-wide-modal' title='wide modal' usageTitle='Usage'}}
   {{bourbon-button title='Show wide modal' class='BourbonButton--primary' action=(action 'showBourbonModal' modalWideParams)}}
 {{/freestyle-usage}}
@@ -201,7 +177,6 @@
   <div class="FreestyleUsage-rendered">Params being passed into the example</div>
   ```
     this.set('noPaddingModalParams', {
-      confirmationModal: true,
       noPaddingModal: true,
       title: 'Am I cute?',
       content: 'test-image-content',


### PR DESCRIPTION
- removing `confirmationModal` option since we are moving forward with having all modals have the same `text-align: left` styles.

BEFORE
<img width="1070" alt="screen shot 2019-02-04 at 4 32 21 pm" src="https://user-images.githubusercontent.com/1967604/52246388-87354280-289a-11e9-9525-717d8091b579.png">
<img width="745" alt="screen shot 2019-02-04 at 4 32 11 pm" src="https://user-images.githubusercontent.com/1967604/52246389-87354280-289a-11e9-8852-788fed0cd6b7.png">
<img width="732" alt="screen shot 2019-02-04 at 4 32 02 pm" src="https://user-images.githubusercontent.com/1967604/52246390-87354280-289a-11e9-8ca6-d249f816f9b0.png">

AFTER
<img width="786" alt="screen shot 2019-02-04 at 4 31 10 pm" src="https://user-images.githubusercontent.com/1967604/52246391-87354280-289a-11e9-9d77-745e66c2245a.png">
<img width="952" alt="screen shot 2019-02-04 at 4 28 19 pm" src="https://user-images.githubusercontent.com/1967604/52246392-87354280-289a-11e9-867e-ea9e2974e6de.png">
<img width="690" alt="screen shot 2019-02-04 at 4 28 08 pm" src="https://user-images.githubusercontent.com/1967604/52246393-87354280-289a-11e9-9aac-6582657de318.png">
