### PR TITLE
Rewrite BourbonSelectField.findValueObject.

### DIFF
--- a/addon/components/bourbon-select-field.js
+++ b/addon/components/bourbon-select-field.js
@@ -63,12 +63,7 @@ export default Component.extend(SelectMixin, {
   },
 
   findValueObject(valueString) {
-    for (var optIndex in this.get('content')) {
-      if (this.get('content')[optIndex].label === valueString) {
-        return this.get('content')[optIndex];
-      }
-    }
-
+    this.get('content').find(v => v.label == valueString)
   },
 
   keyDown(e) {


### PR DESCRIPTION
Switched from `for..in` to `Array.find` for compatibility with `Ember.Array`.