### PR TITLE
Change type to get consistent behavior for search select field.

### DIFF
--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -8,7 +8,7 @@ export default TextField.extend({
     'value::empty',
     'isFocused:BourbonTextField--active'
   ],
-  attributeBindings: ['autocomplete'],
+  attributeBindings: ['autocomplete', 'type'],
 
   layout,
 

--- a/addon/templates/components/bourbon-search-select-field.hbs
+++ b/addon/templates/components/bourbon-search-select-field.hbs
@@ -1,5 +1,5 @@
 <div class="BourbonSearchSelectField-inputContainer">
-  {{bourbon-text-field placeholder=prompt value=inputValue autocomplete="nope" actionOnFocusIn=(action 'showContent') actionOnFocusOut=(action 'hideContent')}}
+  {{bourbon-text-field placeholder=prompt value=inputValue autocomplete="off" actionOnFocusIn=(action 'showContent') actionOnFocusOut=(action 'hideContent') type="search"}}
 </div>
 
 <div class="BourbonSearchSelectField-searchContainer">


### PR DESCRIPTION
It is noted that changing the `type` to `type=search` is something that Chrome will disable autocomplete for that input field.  It makes sense that this type be applied to the `bourbon-search-select-field` since it is what that component is doing.

https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off