### PR TITLE
6078: refactor css causing actions bug in flabongo

### DIFF
--- a/addon/tailwind/components/bourbon-search-select-field.css
+++ b/addon/tailwind/components/bourbon-search-select-field.css
@@ -49,12 +49,10 @@
   cursor: pointer;
 }
 
-.BourbonSearchSelectField-searchContainer .BourbonSelectField {
-  top: -42px;
-}
-
+.BourbonSearchSelectField-searchContainer .BourbonSelectField,
 .BourbonSearchSelectField-searchContainer .BourbonSelectField-menu {
-  top: 40px;
+  position: absolute;
+  top: 0px;
 }
 
 .BourbonSearchSelectField--disabled {

--- a/addon/tailwind/components/bourbon-select-field.css
+++ b/addon/tailwind/components/bourbon-select-field.css
@@ -8,7 +8,7 @@
   line-height: 1em;
   white-space: normal;
   transform: rotateZ(0);
-  min-width: 15em;
+  min-width: 14em;
   height: 3em;
   @apply .btw-bg-white;
   @apply .btw-text-slate;

--- a/addon/tailwind/components/bourbon-text-field.css
+++ b/addon/tailwind/components/bourbon-text-field.css
@@ -8,6 +8,7 @@
   border-radius: 4px;
   box-shadow: 0 1px 2px 0 rgba(0,0,0,0.08);
   width: 100%;
+  min-width: 14em;
   height: 3em;
 }
 

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1364,12 +1364,10 @@ body {
   cursor: pointer;
 }
 
-.BourbonSearchSelectField-searchContainer .BourbonSelectField {
-  top: -42px;
-}
-
+.BourbonSearchSelectField-searchContainer .BourbonSelectField,
 .BourbonSearchSelectField-searchContainer .BourbonSelectField-menu {
-  top: 40px;
+  position: absolute;
+  top: 0;
 }
 
 .BourbonSearchSelectField--disabled {
@@ -1386,7 +1384,7 @@ body {
   line-height: 1em;
   white-space: normal;
   transform: rotateZ(0);
-  min-width: 15em;
+  min-width: 14em;
   height: 3em;
   background-color: #fff;
   color: #474c4f;
@@ -1560,6 +1558,7 @@ body {
   border-radius: 4px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .08);
   width: 100%;
+  min-width: 14em;
   height: 3em;
 }
 


### PR DESCRIPTION
fix: positioning `bourbon-select-field` rather than just using `top` which made the "hidden" part of of the select-field still clickable.

BEFORE
![image](https://user-images.githubusercontent.com/1967604/56240371-32efd100-6048-11e9-84a1-fc68b2311319.png)


AFTER
![image](https://user-images.githubusercontent.com/1967604/56240335-15bb0280-6048-11e9-855e-6e20b3b8f261.png)
