### PR TITLE
6124: adding tabindex and explicit change to showList for safari and …

### DIFF
--- a/addon/components/new-bourbon-select-field.js
+++ b/addon/components/new-bourbon-select-field.js
@@ -14,7 +14,7 @@ export default Component.extend({
     'showList:BourbonSelectField--active',
     'disabled:BourbonSelectField--disabled'
   ],
-  attributeBindings: ['disabled:disabled'],
+  attributeBindings: ['disabled:disabled', 'tabindex:tabindex'],
 
   // passed in
   content: null,
@@ -29,6 +29,7 @@ export default Component.extend({
   showList: false,
   activeDescendant: null,
   hasValue: computed.notEmpty('value'),
+  tabindex: "0",
 
   didRender() {
     this.set(
@@ -203,6 +204,8 @@ export default Component.extend({
   actions: {
     selectIndex(index) {
       this.set('selectedIndex', index);
+      // to deal with focusOut not being triggered upon selection in Safari & FF
+      this.set('showList', false);
     },
 
     mouseDown() {


### PR DESCRIPTION
…firefox

- previously `focusOut` wasn't being triggered in Safari and Firefox because the original component wasn't being focused on. Once opened the dropdown didn't close even when clicking on an option or clicking outside the element.  By adding the `tabindex=0` to the element, it now triggers the `focusOut` when clicking outside the element. 