### PR TITLE
6129: adding attributes to html and update examples

### DIFF
--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -25,8 +25,8 @@ export default Component.extend({
 
   // attribute binding doesn't work for readonly = false
   // https://stackoverflow.com/questions/16109358/what-is-the-correct-readonly-attribute-syntax-for-input-text-elements
-  boundReadOnly: computed('disabled', function() {
-    return this.get('disabled') || null;
+  boundReadOnly: computed('readonly', function() {
+    return this.get('readonly') || null;
   }),
 
   focusedElementObserver: observer('autofocus', function() {

--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -10,12 +10,6 @@ export default Component.extend({
     'isFocused:BourbonTextField--active',
     'isNotEmpty:BourbonTextField--not-empty'
   ],
-  attributeBindings: [
-    'autocomplete',
-    'type',
-    'autofocus',
-    'boundReadOnly:readonly'
-  ],
 
   layout,
 
@@ -31,8 +25,8 @@ export default Component.extend({
 
   // attribute binding doesn't work for readonly = false
   // https://stackoverflow.com/questions/16109358/what-is-the-correct-readonly-attribute-syntax-for-input-text-elements
-  boundReadOnly: computed('readonly', function() {
-    return this.get('readonly') || null;
+  boundReadOnly: computed('disabled', function() {
+    return this.get('disabled') || null;
   }),
 
   focusedElementObserver: observer('autofocus', function() {

--- a/addon/templates/components/bourbon-text-field.hbs
+++ b/addon/templates/components/bourbon-text-field.hbs
@@ -1,2 +1,2 @@
 <label class="BourbonTextField-label">{{placeholder}}</label>
-<input class="BourbonTextField-input" type="text" placeholder={{placeholder}} value={{value}}>
+<input class="BourbonTextField-input" type={{type}} placeholder={{placeholder}} value={{value}} disabled={{disabled}} autocomplete={{autocomplete}} autofocus={{autofocus}} readonly={{boundReadOnly}}>

--- a/addon/templates/components/bourbon-text-field.hbs
+++ b/addon/templates/components/bourbon-text-field.hbs
@@ -1,2 +1,2 @@
 <label class="BourbonTextField-label">{{placeholder}}</label>
-<input class="BourbonTextField-input" type={{type}} placeholder={{placeholder}} value={{value}} disabled={{disabled}} autocomplete={{autocomplete}} autofocus={{autofocus}} readonly={{boundReadOnly}}>
+<input class="BourbonTextField-input" type="text" placeholder={{placeholder}} value={{value}} disabled={{disabled}} autocomplete={{autocomplete}} autofocus={{autofocus}} readonly={{boundReadOnly}}>

--- a/stories/TextField/TextField.stories.js
+++ b/stories/TextField/TextField.stories.js
@@ -27,4 +27,28 @@ storiesOf('text field', module)
     {
       notes: { markdown: textField }
     }
+  )
+  .add(
+    'autofocus textfield',
+    () => {
+      return {
+        template: hbs`{{bourbon-text-field placeholder="i am the placeholder" autofocus=true onFocusOutOrEnter=onClick}}`,
+        context: { onClick: action('textFieldClick') }
+      };
+    },
+    {
+      notes: { markdown: textField }
+    }
+  )
+  .add(
+    'disabled textfield',
+    () => {
+      return {
+        template: hbs`{{bourbon-text-field placeholder="i am the disabled text-field" disabled=true onFocusOutOrEnter=onClick}}`,
+        context: { onClick: action('textFieldClick') }
+      };
+    },
+    {
+      notes: { markdown: textField }
+    }
   );

--- a/stories/TextField/textField.md
+++ b/stories/TextField/textField.md
@@ -17,6 +17,9 @@
 | placeholder | string | null | false | if you want a placehoder prompt to guide user| for example, "Select a Salesforce object..."|
 | noLabel | boolean | false | false | if you don't want to show label pass true ||
 | autofocus | boolean | false | false | if you want the text field focused on load ||
+| disabled | boolean | false | false | if you want the text field disabled ||
+| readonly | boolean | null | false | if you want the text field to have readonly attribute ||
+| autocomplete | boolean | null | false | if you want the text field to have autocomplete attribute ||
 | isFocused | boolean | false | false | if you want the text field is focused ||
 | actionOnFocusIn | function | "" | false | action to be taken when focused into the text field ||
 | actionOnFocusOut | function | "" | false | action to be taken when focused out of the text field ||

--- a/tests/integration/components/bourbon-text-field-test.js
+++ b/tests/integration/components/bourbon-text-field-test.js
@@ -14,4 +14,13 @@ module('Integration | Component | bourbon-text-field', function(hooks) {
 
     assert.equal(this.element.textContent.trim(), '');
   });
+
+  test('it is disabled', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{bourbon-text-field disabled=true}}`);
+
+    assert.equal(this.element.children[0].innerHTML.trim(), '<label class="BourbonTextField-label"></label>\n<input class="BourbonTextField-input" disabled="">');
+  });
 });

--- a/tests/integration/components/bourbon-text-field-test.js
+++ b/tests/integration/components/bourbon-text-field-test.js
@@ -21,6 +21,6 @@ module('Integration | Component | bourbon-text-field', function(hooks) {
 
     await render(hbs`{{bourbon-text-field disabled=true}}`);
 
-    assert.equal(this.element.children[0].innerHTML.trim(), '<label class="BourbonTextField-label"></label>\n<input class="BourbonTextField-input" disabled="">');
+    assert.equal(this.element.children[0].innerHTML.trim(), '<label class="BourbonTextField-label"></label>\n<input class="BourbonTextField-input" disabled="" type="text">');
   });
 });


### PR DESCRIPTION
- before they were `attributeBindings` because the attribute was on the text field.  the new text-field is no longer extending off the `@ember/component/text-field`, so I need to add the attributes on the input directly. 