### PR TITLE
#6190: Override `input:disabled` Firefox browser styling for Bourbon Text Fields

### DIFF
--- a/addon/tailwind/components/bourbon-text-field.css
+++ b/addon/tailwind/components/bourbon-text-field.css
@@ -64,6 +64,7 @@ input[type="search"].BourbonTextField {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: normal;
+  color: inherit;
 }
 
 .BourbonTextField--not-empty .BourbonTextField-label    {


### PR DESCRIPTION
Override `input:disabled` Firefox browser styling for `BourbonTextField-input`

before:
![image](https://user-images.githubusercontent.com/15895216/57548780-af5b9400-7316-11e9-8849-565a07d63cfc.png)


after:
![image](https://user-images.githubusercontent.com/15895216/57548800-b71b3880-7316-11e9-828e-216e154dd437.png)


inspector when I add the class:
![image](https://user-images.githubusercontent.com/15895216/57548827-cdc18f80-7316-11e9-95d7-4fab5259d922.png)
