### PR TITLE
#6190: Override `input:disabled` Firefox browser styling - vendor.css change

### DIFF
--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1617,6 +1617,7 @@ input[type="search"].BourbonTextField {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: normal;
+  color: inherit;
 }
 
 .BourbonTextField--not-empty .BourbonTextField-label {


### PR DESCRIPTION
I forgot to run `ember serve` to generate the new `vendor.css` file when doing work for this PR https://github.com/MatchbookLabs/bourbon/pull/145 😑 


(`vendor.css` file aggregates all the bourbon styles and is what gets imported to flabongo)