### PR TITLE
6283: key up and down on all, only 1 dropdown open at a time, and sea…

### DIFF
--- a/addon/components/bourbon-select-field.js
+++ b/addon/components/bourbon-select-field.js
@@ -27,7 +27,7 @@ export default Component.extend(SelectMixin, ClickHandlerMixin, {
   disabled: false,
 
   clickHandler(e) {
-    if (e.target !== document.activeElement) {
+    if (e.target !== document.activeElement || document.activeElement.textContent != this.get('label')) {
       this.set('activeOption', null);
       this.set('showList', false);
     }

--- a/addon/components/new-bourbon-select-field.js
+++ b/addon/components/new-bourbon-select-field.js
@@ -47,7 +47,7 @@ export default Component.extend(ClickHandlerMixin, {
   },
 
   clickHandler(e) {
-    if (e.target !== document.activeElement) {
+    if (e.target !== document.activeElement || document.activeElement.textContent !== this.get('label')) {
       this.set('showList', false);
     }
   },
@@ -177,18 +177,28 @@ export default Component.extend(ClickHandlerMixin, {
   }),
 
   keyDown(e) {
+    let el = $(e.currentTarget);
+    let list = el.find('.BourbonSelectField-menu');
+
     if (e.keyCode === 38) {
       // up arrow
       this.moveActiveUp(this.get('activeIndex'));
+      let itemHeight = el.find('.NewBourbonSelectField-option')[this.get('activeIndex') + 1].offsetHeight;
+      let scrollHeight = ((this.get('activeIndex') - 1) * itemHeight);
+      list.scrollTop(scrollHeight);
     } else if (e.keyCode === 40) {
       // down arrow
       this.moveActiveDown(this.get('activeIndex'));
+      let itemHeight = el.find('.NewBourbonSelectField-option')[this.get('activeIndex') - 1].offsetHeight;
+      let scrollHeight = (this.get('activeIndex') * itemHeight);
+      list.scrollTop(scrollHeight);
     } else if (e.keyCode === 13) {
       //  enter
       if (this.get('showList')) {
         this.set('selectedIndex', this.get('activeIndex'));
         // triggers the focusOut to hide the list
         document.activeElement.blur();
+        this.set('showList', false);
       } else {
         // When user is focused in and presses
         // enter we want to show the list
@@ -215,7 +225,7 @@ export default Component.extend(ClickHandlerMixin, {
   },
 
   moveActiveDown(prevIndex) {
-    let nextIndex = prevIndex + 1;
+    let nextIndex = prevIndex === null ? 0 : prevIndex + 1;
     if (nextIndex >= this.get('internalContent.length')) {
       return;
     } else {

--- a/addon/mixins/select.js
+++ b/addon/mixins/select.js
@@ -146,9 +146,7 @@ export default Mixin.create({
   },
 
   scrollList(item, list) {
-    let listHeight = list.height();
-    let totalHeight = (this.get('activeOption') + 1) * item.scrollHeight;
-    let scrollHeight = totalHeight - listHeight;
-    list.scrollTop(scrollHeight);
+    let itemHeight = (this.get('activeOption')) * item.scrollHeight;
+    list.scrollTop(itemHeight);
   }
 });

--- a/addon/tailwind/components/bourbon-search-select-field.css
+++ b/addon/tailwind/components/bourbon-search-select-field.css
@@ -46,8 +46,8 @@
   padding: 4px;
   transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
-  cursor: pointer;
   z-index: 1;
+  pointer-events: none;
 }
 
 .BourbonSearchSelectField-searchContainer {

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1362,8 +1362,8 @@ body {
   padding: 4px;
           transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
-  cursor: pointer;
   z-index: 1;
+  pointer-events: none;
 }
 
 .BourbonSearchSelectField-searchContainer {

--- a/stories/NewSelectField/NewSelectField.stories.js
+++ b/stories/NewSelectField/NewSelectField.stories.js
@@ -96,7 +96,7 @@ storiesOf('new select field', module)
     'multiple select fields',
     () => {
       return {
-        template: hbs`<div class="btw-flex btw-max-w-sm">{{new-bourbon-select-field content=petObject optionLabelPath="content.label" optionValuePath="content.value" fullWidth=true value='the other Brussels Griffon'}} {{new-bourbon-select-field content=petObject optionLabelPath="content.label" optionValuePath="content.value"}}</div>`,
+        template: hbs`<div class="btw-flex btw-max-w-sm">{{new-bourbon-select-field content=petObject optionLabelPath="content.label" optionValuePath="content.value" fullWidth=true prompt="Select a dog..."}} {{new-bourbon-select-field content=petObject optionLabelPath="content.label" optionValuePath="content.value" prompt="Select a second dog..."}}</div>`,
         context: {
           onClick: action('selectFieldClick'),
           petObject: A([
@@ -111,7 +111,15 @@ storiesOf('new select field', module)
             {
               label: 'Macho the Frenchie who is so Frenchie Macho the Frenchie who is so Frenchie',
               value: 'Frenchie'
-            }
+            },
+            {
+              label: 'Cosmos the Klee Kai',
+              value: 'Klee Kai'
+            },
+            {
+              label: 'Luna the chihuahua mix',
+              value: 'Chihuahua'
+            },
           ])
         }
       };

--- a/stories/SearchSelectField/SearchSelectField.stories.js
+++ b/stories/SearchSelectField/SearchSelectField.stories.js
@@ -115,7 +115,7 @@ storiesOf('search select field', module)
     'multiple search select fields',
     () => {
       return {
-        template: hbs`<div class="btw-flex btw-max-w-sm">{{bourbon-search-select-field content=petsArray prompt="Select an animal..." value="Select an animal..."}}{{bourbon-search-select-field content=petsArray prompt="Select an animal..."}}</div>`,
+        template: hbs`<div class="btw-flex btw-max-w-sm">{{bourbon-search-select-field content=petsArray prompt="Select an animal..." value="Select an animal..."}}{{bourbon-search-select-field content=petsArray prompt="Select another animal..."}}</div>`,
         context: {
           onClick: action('searchSelectFieldClick'),
           petsArray: A([


### PR DESCRIPTION
…rch arrow fix

fixes the following bugs
1. only show 1 dropdown at a time.
2. able to key up and down on all types of select fields now properly (included grouped content).  before the scroll wasn't following the active option.
3. clicking on the carat in the search was making the showlist behavior behave inconsistently