### PR TITLE
6204: making sure label is not visible when hidden

### DIFF
--- a/addon/tailwind/components/bourbon-text-field.css
+++ b/addon/tailwind/components/bourbon-text-field.css
@@ -52,6 +52,7 @@ input[type="search"].BourbonTextField {
   white-space: nowrap;
   width: auto;
   z-index: 1;
+  visibility: hidden;
 }
 
 .BourbonTextField-input {
@@ -71,4 +72,5 @@ input[type="search"].BourbonTextField {
   opacity: 1;
   transform: none;
   top: -8px;
+  visibility: visible;
 }

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1609,6 +1609,7 @@ input[type="search"].BourbonTextField {
   white-space: nowrap;
   width: auto;
   z-index: 1;
+  visibility: hidden;
 }
 
 .BourbonTextField-input {
@@ -1628,6 +1629,7 @@ input[type="search"].BourbonTextField {
   opacity: 1;
   transform: none;
   top: -8px;
+  visibility: visible;
 }
 
 .BourbonTooltip {


### PR DESCRIPTION
without the visibility property even when the user passes in `noLabel`, it took up space in and made the part of the text field that had the label un-clickable.  