### PR TITLE
(#6344): checking default passed in is actually enabled

### DIFF
--- a/addon/components/new-bourbon-select-field.js
+++ b/addon/components/new-bourbon-select-field.js
@@ -44,10 +44,13 @@ export default Component.extend(ClickHandlerMixin, {
     }
 
     if (this.get('defaultSelection') && this.get('value') === undefined) {
-      this.set(
-        'selectedIndex',
-        this.get('content').indexOf(this.get('defaultSelection'))
-      );
+      // need to check if defaultSelection is valid & only update if enabled
+      let defaultSelectionIndex = this.get('content').indexOf(this.get('defaultSelection'));
+      let defaultSelectionEnabled = this.get('internalContent')[defaultSelectionIndex].enabled;
+
+      if (defaultSelectionEnabled) {
+        this.set('selectedIndex', defaultSelectionIndex);
+      }
     }
   },
 


### PR DESCRIPTION
Before, it was setting the `defaultSelection` that was passed even it wasn't enabled.  This was discovered in  testing with the builder when the defaultSelection being passed was a grid question which is not supported/enabled in that section but was still being set.  