### PR TITLE
6431: decouple search select field & bourbon-text-field

### DIFF
--- a/addon/components/bourbon-search-select-field.js
+++ b/addon/components/bourbon-search-select-field.js
@@ -46,6 +46,13 @@ export default Component.extend(SelectMixin, ClickHandlerMixin, {
     }
   },
 
+  input(e) {
+    let el = $(e.currentTarget);
+    let textInput = el.find('.BourbonTextField-input').val();
+
+    this.set('inputValue', textInput);
+  },
+
   resetPrompt: observer('label', 'value', function() {
     if (this.get('value') === null && this.get('prompt')) {
       this.set('inputValue', this.get('prompt'));

--- a/addon/templates/components/bourbon-search-select-field.hbs
+++ b/addon/templates/components/bourbon-search-select-field.hbs
@@ -1,5 +1,8 @@
 <div class="BourbonSearchSelectField-inputContainer" {{action "mouseDown"}}>
-  {{bourbon-text-field placeholder=prompt noLabel=true value=inputValue autofocus=autofocus readonly=readonly autocomplete="off" type="search"}}
+  <div class="BourbonTextField {{if isFocused 'BourbonTextField--active'}}">
+    <label class="BourbonTextField-label">{{prompt}}</label>
+    <input class="BourbonTextField-input" type="search" placeholder={{prompt}} value={{inputValue}}>
+  </div>
 </div>
 {{#if showDropdown}}
   <div class="BourbonSearchSelectField-searchContainer">

--- a/addon/templates/components/bourbon-search-select-field.hbs
+++ b/addon/templates/components/bourbon-search-select-field.hbs
@@ -1,6 +1,5 @@
 <div class="BourbonSearchSelectField-inputContainer" {{action "mouseDown"}}>
   <div class="BourbonTextField {{if isFocused 'BourbonTextField--active'}}">
-    <label class="BourbonTextField-label">{{prompt}}</label>
     <input class="BourbonTextField-input" type="search" placeholder={{prompt}} value={{inputValue}}>
   </div>
 </div>


### PR DESCRIPTION
last change to `bourbon-text-field` caused an issue in the `bourbon-search-select-field`.  
https://github.com/MatchbookLabs/bourbon/pull/160

no reason to link these 2 components, so removing `bourbon-text-field` from the `bourbon-search-select-field`.  