### PR TITLE
6431: refactor text-field to deal with safari bug

### DIFF
--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -37,8 +37,8 @@ export default Component.extend({
     this.set('isFocused', this.get('autofocus'));
   }),
 
-  isNotEmpty: computed('textInput', function() {
-    return this.get('textInput') && !this.get('noLabel');
+  isNotEmpty: computed('value', function() {
+    return this.get('value') && !this.get('noLabel');
   }),
 
   didInsertElement() {
@@ -65,7 +65,7 @@ export default Component.extend({
     this.set('textInput', textInput);
   },
 
-  valueObserver: computed('textInput', function() {
+  valueObserver: observer('textInput', function() {
     this.set('value', this.get('textInput'));
   }),
 

--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -60,13 +60,17 @@ export default Component.extend({
     let textInput = el.find('.BourbonTextField-input').val();
 
     // setting value directly here was causing the cursor to
-    // jump to the end of the input field in safari.
+    // jump to the end of the input field in safari. So have a holder
+    // variable and then observer to properly set value in valueObserver
     this.set('textInput', textInput);
   },
 
+  valueObserver: computed('textInput', function() {
+    this.set('value', this.get('textInput'));
+  }),
+
   focusOut() {
     this.set('isFocused', false);
-    this.set('value', this.get('textInput'));
     document.activeElement.blur();
 
     if (this.get('onFocusOutOrEnter')) {
@@ -80,8 +84,6 @@ export default Component.extend({
 
   keyDown(e) {
     if (e.keyCode === 13) {
-      this.set('value', this.get('textInput'));
-
       if (this.get('actionOnEnter')) {
         this.get('actionOnEnter')(this.get('value'));
       }


### PR DESCRIPTION
previous fix was causing unintended bugs since it was changing the behavior of the text-field: https://github.com/MatchbookLabs/bourbon/pull/160

updated to use an observer to deal the previous safari issue of cursor jumping to the end.