### PR TITLE
(#6431): use an ember input instead of html input to deal with safari bug 

### DIFF
--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -19,7 +19,6 @@ export default Component.extend({
   autofocus: false,
   readonly: null,
   value: null,
-  textInput: null,
   isFocused: false,
   noLabel: false,
 
@@ -58,15 +57,11 @@ export default Component.extend({
   input(e) {
     let el = $(e.currentTarget);
     let textInput = el.find('.BourbonTextField-input').val();
-
-    // setting value directly here was causing the cursor to
-    // jump to the end of the input field in safari.
-    this.set('textInput', textInput);
+    this.set('value', textInput);
   },
 
   focusOut() {
     this.set('isFocused', false);
-    this.set('value', this.get('textInput'));
     document.activeElement.blur();
 
     if (this.get('onFocusOutOrEnter')) {
@@ -80,8 +75,6 @@ export default Component.extend({
 
   keyDown(e) {
     if (e.keyCode === 13) {
-      this.set('value', this.get('textInput'));
-
       if (this.get('actionOnEnter')) {
         this.get('actionOnEnter')(this.get('value'));
       }

--- a/addon/components/bourbon-text-field.js
+++ b/addon/components/bourbon-text-field.js
@@ -37,8 +37,8 @@ export default Component.extend({
     this.set('isFocused', this.get('autofocus'));
   }),
 
-  isNotEmpty: computed('textInput', function() {
-    return this.get('textInput') && !this.get('noLabel');
+  isNotEmpty: computed('value', function() {
+    return this.get('value') && !this.get('noLabel');
   }),
 
   didInsertElement() {

--- a/addon/templates/components/bourbon-text-field.hbs
+++ b/addon/templates/components/bourbon-text-field.hbs
@@ -1,2 +1,2 @@
 <label class="BourbonTextField-label">{{placeholder}}</label>
-<input class="BourbonTextField-input" type={{fieldType}} placeholder={{placeholder}} value={{value}} disabled={{disabled}} autocomplete={{autocomplete}} autofocus={{autofocus}} readonly={{boundReadOnly}} maxlength={{maxlength}}>
+{{input class="BourbonTextField-input" type=fieldType placeholder=placeholder value=value disabled=disabled autocomplete=autocomplete autofocus=autofocus readonly=boundReadOnly maxlength=maxlength}}

--- a/tests/integration/components/bourbon-text-field-test.js
+++ b/tests/integration/components/bourbon-text-field-test.js
@@ -21,6 +21,16 @@ module('Integration | Component | bourbon-text-field', function(hooks) {
 
     await render(hbs`{{bourbon-text-field disabled=true}}`);
 
-    assert.equal(this.element.children[0].innerHTML.trim(), '<label class="BourbonTextField-label"></label>\n<input id="ember412" disabled="" class="BourbonTextField-input ember-text-field ember-view" type="text">');
+    assert.equal(this.$('.BourbonTextField-input').attr('disabled'), 'disabled');
+  });
+
+  test('it has a placeholder', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+
+    await render(hbs`{{bourbon-text-field placeholder="hello world"}}`);
+
+    assert.equal(this.element.children[0].textContent.trim(), 'hello world');
   });
 });

--- a/tests/integration/components/bourbon-text-field-test.js
+++ b/tests/integration/components/bourbon-text-field-test.js
@@ -21,6 +21,6 @@ module('Integration | Component | bourbon-text-field', function(hooks) {
 
     await render(hbs`{{bourbon-text-field disabled=true}}`);
 
-    assert.equal(this.element.children[0].innerHTML.trim(), '<label class="BourbonTextField-label"></label>\n<input class="BourbonTextField-input" disabled="" type="text">');
+    assert.equal(this.element.children[0].innerHTML.trim(), '<label class="BourbonTextField-label"></label>\n<input id="ember412" disabled="" class="BourbonTextField-input ember-text-field ember-view" type="text">');
   });
 });

--- a/tests/integration/components/bourbon-text-field-test.js
+++ b/tests/integration/components/bourbon-text-field-test.js
@@ -16,19 +16,12 @@ module('Integration | Component | bourbon-text-field', function(hooks) {
   });
 
   test('it is disabled', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
     await render(hbs`{{bourbon-text-field disabled=true}}`);
 
     assert.equal(this.$('.BourbonTextField-input').attr('disabled'), 'disabled');
   });
 
   test('it has a placeholder', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-
     await render(hbs`{{bourbon-text-field placeholder="hello world"}}`);
 
     assert.equal(this.element.children[0].textContent.trim(), 'hello world');


### PR DESCRIPTION
previous fix was causing unintended bugs since it was changing the behavior of the text-field: #160

1. reverting that change
2. using the html input instead of the ember input field was causing the cursor to jump to the end of the input field in safari

