### PR TITLE
(#6446) update new-select field to handle disabled options

### DIFF
--- a/addon/components/new-bourbon-select-field.js
+++ b/addon/components/new-bourbon-select-field.js
@@ -57,7 +57,7 @@ export default Component.extend(ClickHandlerMixin, {
   },
 
   clickHandler(e) {
-    if (e.target !== document.activeElement || document.activeElement.textContent !== this.get('label')) {
+    if (!e.target.isEqualNode(document.activeElement)) {
       this.set('showList', false);
     }
   },

--- a/addon/tailwind/components/bourbon-select-field.css
+++ b/addon/tailwind/components/bourbon-select-field.css
@@ -94,7 +94,7 @@
   @apply .btw-bg-concrete;
 }
 
-.BourbonSelectField-option[disabled="true"] {
+.BourbonSelectField-option[disabled] {
   pointer-events: none;
   opacity: .4;
 }

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -1472,7 +1472,7 @@ body {
   background-color: #f3f3f3;
 }
 
-.BourbonSelectField-option[disabled="true"] {
+.BourbonSelectField-option[disabled] {
   pointer-events: none;
   opacity: .4;
 }


### PR DESCRIPTION
This PR fixes some issues with the `new-bourbon-select-field` when all of the options are disabled. It also fixes the attribute selector for disabled options.