### PR TITLE
Bump node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "webpack": "^4.27.1"
   },
   "engines": {
-    "node": "~10.16.0",
+    "node": "^10.16.0",
     "npm": "~6.4.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Heroku added a new version of Node 10 (10.17.0) that is causing build to fail.