### PR TITLE
GFPPLAN-64 Remove global font rule

### DIFF
--- a/addon/tailwind/components/base.css
+++ b/addon/tailwind/components/base.css
@@ -27,7 +27,3 @@ making styling changes in the library */
   @apply .btw-border-dodger-blue;
   outline-color: var(--dodger-blue);
 }
-
-body {
-  font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-}

--- a/dist/assets/vendor.css
+++ b/dist/assets/vendor.css
@@ -826,10 +826,6 @@ making styling changes in the library */
   outline-color: var(--dodger-blue);
 }
 
-body {
-  font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
-}
-
 .BourbonAccordionItem-body {
   display: none;
   padding: 25px 0;


### PR DESCRIPTION
This is to support the new branding effort. Flabongo should control which font family is used.